### PR TITLE
Linter improvements: PRO-2314 PRO-2325 PRO-2330 PRO-2328 PRO-2359 PRO-2313 PRO-2311 PRO-2378

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## UNRELEASED
+
+- Adds helpful message about using "git diff HEAD" after running the upgrade command.
+- Display lint messages in source code order, even if they are for a mix of issues.
+- Lint for array field schema properties that need conversion.
+- Lint for joinByArray field sub-schema properties that need conversion.
+- Lint for joinByOne, joinByArray, joinbyOneReverse, and joinByArrayReverse.
+- Lint for widget output method overrides.
+- Lint for `filterOptionsForDataAttribute`.
+- Lint for methods that should move to the "methods" section.
+- Lint for tasks that should move to the "tasks" section.
+
 ## 1.0.0-alpha.1 (2021-12-03)
 
 - Adds missing `glob` npm dependency needed for `npm install -g`. Previously a transient dependency allowed this to work in some cases but not all.

--- a/lib/glob-by-extension.js
+++ b/lib/glob-by-extension.js
@@ -6,7 +6,8 @@ module.exports = (extension) => {
       'dist/**/*',
       '**/node_modules/**',
       '**/public/**/*',
-      '**/private/**/*'
+      '**/private/**/*',
+      'apos-build/**/*'
     ]
   });
 };

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -121,7 +121,7 @@ ${getMessage({
   match
 }, options.message)}
 ${options.url ? `\nSee: ${options.url}\n` : ''}
-          `
+          `.trim()
         });
         matched = true;
       }
@@ -138,7 +138,7 @@ ${options.url ? `\nSee: ${options.url}\n` : ''}
     });
 
     for (const result of results) {
-      console.error(result.error);
+      console.error(result.error + '\n');
     }
   }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const acorn = require('acorn');
 const glob = require('glob');
+const { stripIndent } = require('common-tags');
 
 const linters = require('./linters.js');
 const get = require('./get.js');
@@ -56,6 +57,8 @@ module.exports = ({ argv }) => {
     const src = fs.readFileSync(file, { encoding: 'utf8' });
     let parsed;
 
+    const results = [];
+
     if (file.match(/\.js$/)) {
       let ast;
       try {
@@ -105,19 +108,38 @@ module.exports = ({ argv }) => {
       for (const match of matches) {
         // Don't mess up if index is 0
         const line = indexToLine(src, (match.index !== undefined) ? match.index : match.start);
-        console.error(`${file}, line ${line.lineNumber}:\n`);
-        console.error(line.text);
-        console.error(' '.repeat(line.columnNumber - 1) + '^');
-        console.error(getMessage({
-          src,
-          line,
-          match
-        }, options.message) + '\n');
-        if (options.url) {
-          console.error(`See: ${options.url}\n`);
-        }
+        results.push({
+          lineNumber: line.lineNumber,
+          // stripIndent just doesn't work here and I don't know why
+          error: `
+${file}, line ${line.lineNumber}:
+
+${line.text}
+${' '.repeat(line.columnNumber - 1) + '^'}
+${getMessage({
+  src,
+  line,
+  match
+}, options.message)}
+${options.url ? `See: ${options.url}\n` : '' }
+          `
+        });
         matched = true;
       }
+    }
+
+    results.sort((a, b) => {
+      if (a.lineNumber < b.lineNumber) {
+        return -1;
+      } else if (a.lineNumber > b.lineNumber) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+
+    for (const result of results) {
+      console.error(result.error);
     }
   }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const acorn = require('acorn');
 const glob = require('glob');
-const { stripIndent } = require('common-tags');
 
 const linters = require('./linters.js');
 const get = require('./get.js');
@@ -121,7 +120,7 @@ ${getMessage({
   line,
   match
 }, options.message)}
-${options.url ? `See: ${options.url}\n` : '' }
+${options.url ? `See: ${options.url}\n` : ''}
           `
         });
         matched = true;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -120,7 +120,7 @@ ${getMessage({
   line,
   match
 }, options.message)}
-${options.url ? `See: ${options.url}\n` : ''}
+${options.url ? `\nSee: ${options.url}\n` : ''}
           `
         });
         matched = true;

--- a/lib/linters.js
+++ b/lib/linters.js
@@ -154,7 +154,7 @@ const js = {
     match: /type:\s*["']tags[".]/g,
     message: stripIndent`
       There is no "tags" field type in A3. If you need tags for a particular
-      piece type, add a second piece type for that purpose and create a "relationship"
+      piece type, add a piece type for that purpose and create a "relationship"
       field to connect them.
     `
   },
@@ -162,7 +162,7 @@ const js = {
     match: /apos\.tags|apostrophe-tags/g,
     message: stripIndent`
       There is no "apostrophe-tags" module in A3. If you need tags for a particular
-      piece type, add a second piece type for that purpose and create a "relationship"
+      piece type, add a piece type for that purpose and create a "relationship"
       field to connect them.
     `
   },

--- a/lib/linters.js
+++ b/lib/linters.js
@@ -121,9 +121,140 @@ const js = {
 
       Backend scripts and stylesheets for the admin UI must be repackaged in Vue.
     `
+  },
+  methods: {
+    match: /self\.\w+\s*=.*?(function|=\>)/g,
+    message: stripIndent`
+      Method definitions should be moved to the new "methods" section of the module,
+      unless you are extending an existing method with the old "super" pattern, in
+      which case they should move to the new "extendMethods" section, with a
+      "_super" argument at the beginning.
+    `,
+    url: 'https://v3.docs.apostrophecms.org/reference/module-api/module-overview.html#methods'
+  },
+  browserCall: {
+    match: /apos\.push\.browserCall/g,
+    message: stripIndent`
+      The "apos.push.browserCall" mechanism does not exist in A3. See the
+      new "enableBrowserData" method and implement or extend the "getBrowserData"
+      method to make data available at page load time in the browser, or
+      add data attributes to your markup, or use the REST API after page load time.
+    `
+  },
+  reqCall: {
+    match: /req\.browserCall/g,
+    message: stripIndent`
+      The "req.browserCall" mechanism does not exist in A3. See the
+      new "enableBrowserData" method and implement or extend the "getBrowserData"
+      method to make data available at page load time in the browser, or
+      add data attributes to your markup, or use the REST API after page load time.
+    `
+  },
+  tagsField: {
+    match: /type:\s*["']tags[".]/g,
+    message: stripIndent`
+      There is no "tags" field type in A3. If you need tags for a particular
+      piece type, add a second piece type for that purpose and create a "relationship"
+      field to connect them.
+    `
+  },
+  tagsModule: {
+    match: /apos\.tags|apostrophe-tags/g,
+    message: stripIndent`
+      There is no "apostrophe-tags" module in A3. If you need tags for a particular
+      piece type, add a second piece type for that purpose and create a "relationship"
+      field to connect them.
+    `
+  },
+  joinByOne: {
+    match: /joinByOne/g,
+    message: stripIndent`
+      Apostrophe A3 has no "joinByOne" field type. Use the "relationship" field
+      type instead and set both "required: true" and "max: 1". The loaded data will
+      appear as an array with a single element.
+    `
+  },
+  joinByOneReverse: {
+    match: /joinByOneReverse/g,
+    message: stripIndent`
+      Apostrophe A3 has no "joinByOneReverse" field type. Change your "joinByOne"
+      field to a "relationship" field as noted elsewhere, then change "joinByOneReverse"
+      to "relationshipReverse".
+    `
+  },
+  joinByArray: {
+    match: /joinByArray/g,
+    message: stripIndent`
+      In A3 the "joinByArray" field type has been renamed to "relationship".
+    `
+  },
+  joinByArrayReverse: {
+    match: /joinByArrayReverse/g,
+    message: stripIndent`
+      Apostrophe A3 has no "joinByArrayReverse" field type. Change your "joinByArray"
+      field to a "relationship" field as noted elsewhere, then change "joinByArrayReverse"
+      to "relationshipReverse".
+    `
+  },
+  tasks: {
+    match: /apos\.tasks\.add|self\.addTask/g,
+    message: stripIndent`
+      Apostrophe tasks have moved to the new "tasks" section.
+    `,
+    url: 'https://v3.docs.apostrophecms.org/reference/module-api/module-overview.html#tasks'
+  },
+  widgetOutput: {
+    match: /self\.output\s*=/g,
+    message: stripIndent`
+      Overriding the "output" method of a widget module is usually unnecessary
+      as it simply renders the template. If you must override it be aware
+      that the arguments have changed to:
+      
+      "req, widget, options, _with"
+      
+      Also, the output method is now async.
+    `
+  },
+  filterOptionsForDataAttribute: {
+    match: /filterOptionsForDataAttribute/g,
+    message: stripIndent`
+      filterOptionsForDataAttribute is not needed in A3, as A3 does not add any data
+      attributes to a widget by default, except when editing. Your widget templates
+      are responsible for making any needed data available to widget players via data
+      attributes.
+    `
+  },
+  addFieldType: {
+    match: /(schema|self)\.addFieldType/g,
+    message: stripIndent`
+      Be aware that addFieldType has changed in A3. There is just one "convert"
+      method per field type, which should accept either a string representation
+      for import purposes (CSV, etc) and may also accept a different representation
+      for form submissions where appropriate. "convert" may be async and now receives
+      these arguments, typically copying from "data[field.name]" to
+      "destination[field.name]" after sanitization:
+
+      "req, field, data, destination"
+    `
+  },
+  joinByArraySchema: {
+    match: /(joinByArray|relationship)[\s\S]{1,1000}schema["']?:/,
+    message: stripIndent`
+      It looks like you may have a joinByArray or relationship field
+      with a schema. In addition to changing "joinByArray" to "relationship",
+      you will need to change "schema" to a "fields" property with
+      an "add" subproperty, structured the same way as the "fields"
+      section of a module.
+    `
+  },
+  arraySchema: {
+    match: /(["']array["'])[\s\S]{1,1000}schema["']?:/,
+    message: stripIndent`
+      It looks like you may have an array field with a schema. You will need to
+      change "schema" to a "fields" property with an "add" subproperty, structured
+      the same way as the "fields" section of a module.
+    `
   }
-  // TODO lint apos.push
-  // TODO lint apos.tags
 };
 
 const html = {

--- a/lib/linters.js
+++ b/lib/linters.js
@@ -123,7 +123,7 @@ const js = {
     `
   },
   methods: {
-    match: /self\.\w+\s*=.*?(function|=\>)/g,
+    match: /self\.\w+\s*=.*?(function|=>)/g,
     message: stripIndent`
       Method definitions should be moved to the new "methods" section of the module,
       unless you are extending an existing method with the old "super" pattern, in


### PR DESCRIPTION
- Adds helpful message about using "git diff HEAD" after running the upgrade command.
- Display lint messages in source code order, even if they are for a mix of issues.
- Lint for array field schema properties that need conversion.
- Lint for joinByArray field sub-schema properties that need conversion.
- Lint for joinByOne, joinByArray, joinbyOneReverse, and joinByArrayReverse.
- Lint for widget output method overrides.
- Lint for `filterOptionsForDataAttribute`.
- Lint for methods that should move to the "methods" section.
- Lint for tasks that should move to the "tasks" section.