### PR TITLE
PRO-2323 lint webpack presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Linter now flags the presence of webpack and explains options.
+
 ## 1.0.0-alpha.2 (2021-12-08)
 
 - Adds a prompt before the upgrade script runs to confirm the user wants to proceed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Linter now flags the presence of webpack and explains options.
+- Linter now looks for `webpack.config.js` and explains possible alternatives and options.
 
 ## 1.0.0-alpha.2 (2021-12-08)
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,12 +1,14 @@
 const fs = require('fs');
 const acorn = require('acorn');
 const glob = require('glob');
+const stripIndents = require('common-tags').stripIndents;
 
 const linters = require('./linters.js');
 const get = require('./get.js');
 const globByExtension = require('./glob-by-extension.js');
 
 module.exports = ({ argv }) => {
+  lintWebpack();
   const extensions = Object.keys(linters);
   let matched = false;
   for (const extension of extensions) {
@@ -205,4 +207,25 @@ function matchRule(s, rule) {
 function getMessage(input, message) {
   const formatted = ((typeof message) === 'function') ? message(input) : message;
   return formatted.trim();
+}
+
+function lintWebpack() {
+  if (fs.existsSync('./webpack.config.js')) {
+    console.error(stripIndents`
+      This project contains a webpack.config.js file. Depending on your needs
+      this might not be necessary with A3.
+
+      Frontend scripts can be placed in the ui/src/index.js file of the module or
+      a file imported into it with the import statement. ui/src/index.js must
+      export a function, which will be invoked in the order in which modules are
+      activated.
+
+      Frontend stylesheets can be placed in the ui/src/index.scss file of the module
+      or a file imported into it with the @import statement.
+
+      If this is not sufficient for your needs, then your webpack bundle
+      must be output to the ui/public subdirectory of a module of your choice.
+      This ensures it is incorporated in the Apostrophe bundle without change.
+    `);
+  }
 }

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -215,17 +215,9 @@ function lintWebpack() {
       This project contains a webpack.config.js file. Depending on your needs
       this might not be necessary with A3.
 
-      Frontend scripts can be placed in the ui/src/index.js file of the module or
-      a file imported into it with the import statement. ui/src/index.js must
-      export a function, which will be invoked in the order in which modules are
-      activated.
-
-      Frontend stylesheets can be placed in the ui/src/index.scss file of the module
-      or a file imported into it with the @import statement.
-
-      If this is not sufficient for your needs, then your webpack bundle
-      must be output to the ui/public subdirectory of a module of your choice.
-      This ensures it is incorporated in the Apostrophe bundle without change.
+      See:
+      
+      https://v3.docs.apostrophecms.org/guide/front-end-assets.html
     `);
   }
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

* Lints for presence of webpack, displays helpful message if webpack is in the A2 project

## What are the specific steps to test this change?

*For example:*

* npm link this module, then run `apos-code-upgrader lint` in an A2 project such as bdp-v2 that has webpack

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [N/A] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
