### PR TITLE
Pro 2316 upgrade assembly projects

### DIFF
--- a/lib/glob-by-extension.js
+++ b/lib/glob-by-extension.js
@@ -1,13 +1,29 @@
 const glob = require('glob');
+const ignore = [
+  'dist/**/*',
+  '**/node_modules/**',
+  '**/public/**/*',
+  '**/private/**/*',
+  'apos-build/**/*'
+];
 
-module.exports = (extension) => {
-  return glob.sync(`**/*.${extension}`, {
-    ignore: [
-      'dist/**/*',
-      '**/node_modules/**',
-      '**/public/**/*',
-      '**/private/**/*',
-      'apos-build/**/*'
-    ]
-  });
+module.exports = (extension, pattern) => {
+  if (!pattern) {
+    return glob.sync(`**/*.${extension}`, { ignore });
+
+  } else {
+    const res = glob.sync(pattern, { ignore });
+    console.log('res:', res);
+    return res;
+  }
+};
+
+module.exports = {
+  globByExtension (extension) {
+    return glob.sync(`**/*.${extension}`, { ignore });
+  },
+  globByPattern (pattern) {
+    return glob.sync(pattern, { ignore });
+  }
+
 };

--- a/lib/glob-by-extension.js
+++ b/lib/glob-by-extension.js
@@ -7,17 +7,6 @@ const ignore = [
   'apos-build/**/*'
 ];
 
-module.exports = (extension, pattern) => {
-  if (!pattern) {
-    return glob.sync(`**/*.${extension}`, { ignore });
-
-  } else {
-    const res = glob.sync(pattern, { ignore });
-    console.log('res:', res);
-    return res;
-  }
-};
-
 module.exports = {
   globByExtension (extension) {
     return glob.sync(`**/*.${extension}`, { ignore });
@@ -25,5 +14,4 @@ module.exports = {
   globByPattern (pattern) {
     return glob.sync(pattern, { ignore });
   }
-
 };

--- a/lib/legacy-module-name-map.js
+++ b/lib/legacy-module-name-map.js
@@ -1,4 +1,5 @@
 module.exports = {
+  'apostrophe-multisite': '@apostrophecms-pro/multisite',
   'apostrophe-utils': '@apostrophecms/util',
   'apostrophe-tasks': '@apostrophecms/task',
   'apostrophe-launder': '@apostrophecms/launder',

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -5,7 +5,7 @@ const stripIndents = require('common-tags').stripIndents;
 
 const linters = require('./linters.js');
 const get = require('./get.js');
-const globByExtension = require('./glob-by-extension.js');
+const { globByExtension } = require('./glob-by-extension.js');
 
 module.exports = ({ argv }) => {
   lintWebpack();

--- a/lib/upgrader.js
+++ b/lib/upgrader.js
@@ -92,22 +92,25 @@ function replace({ argv }) {
 
 function renameModulesDeclarations(isMultisite) {
   const files = [
-    './app.js',
+    'app.js',
     ...isMultisite
       ? [
         'dashboard/index.js',
         'sites/index.js',
-        ...globByPattern('./dashboard/lib/theme-*.js'),
-        ...globByPattern('./sites/lib/theme-*.js')
+        ...globByPattern('dashboard/lib/theme-*.js'),
+        ...globByPattern('sites/lib/theme-*.js')
       ]
       : []
   ];
 
-  const replaces = Object.entries(renamedModulesMap).map(([ old, newName ]) => {
-    const oldName = old.replace('dashboard/', '').replace('sites/', '');
+  const renamedReplaces = Object.entries(renamedModulesMap)
+    .map(([ old, newName ]) => {
+      const oldName = old.replace('dashboard/', '').replace('sites/', '');
 
-    return [ `'${oldName}'`, `'${newName}'` ];
-  }, []);
+      return [ oldName, newName ];
+    }, []).filter(([ oldName, newName ]) => !legacyModuleNameMap[oldName]);
+
+  const replaces = [ ...renamedReplaces, ...Object.entries(legacyModuleNameMap) ];
 
   replaceOccurences(files, replaces);
 }
@@ -161,6 +164,7 @@ function refactor({ argv }) {
       processModuleInFolder('modules', moduleName);
     });
 
+    renameModulesDeclarations();
   }
 
   function manageMultiSiteProject() {

--- a/lib/upgrader.js
+++ b/lib/upgrader.js
@@ -89,30 +89,9 @@ function replace({ argv }) {
 function refactor({ argv }) {
   let projectHelpersNeeded = false;
   if (isSingleSiteProject()) {
-    // Only touch directories, don't mess about with regular files in lib/modules
-    // or symlinks in lib/modules
-    let moduleNames = fs.readdirSync('lib/modules').filter(moduleName => fs.lstatSync(`lib/modules/${moduleName}`).isDirectory());
-    moduleNames.forEach(name => {
-      rename(`lib/modules/${name}`, `modules/${name}`);
-    });
-    try {
-      fs.rmdirSync('lib/modules');
-    } catch (e) {
-      if (e.code === 'ENOTEMPTY') {
-        console.error(stripIndent`
-          "lib/modules" is not empty after moving modules to "modules". You probably
-          have files that are not Apostrophe modules in that folder. Please
-          move those files to a more appropriate location, like "lib", then
-          remove "lib/modules" yourself.
-        `);
-      } else {
-        throw e;
-      }
-    }
-    moduleNames = fs.readdirSync('modules');
-    moduleNames.forEach(moduleName => {
-      processModuleInFolder('modules', moduleName);
-    });
+    manageSingleProject();
+  } else if (isMultiSiteProject()) {
+    manageMultiSiteProject();
   } else if (isSingleNpmModule()) {
     processStandaloneModule();
   } else if (isMoogBundle()) {
@@ -121,7 +100,7 @@ function refactor({ argv }) {
       // this is a strong norm
       fail('Currently moog bundles are only supported if they have a lib/modules directory.');
     }
-    processLibModules();
+    manageSingleProject();
     processStandaloneModule();
     console.log(stripIndent`
       ⚠️ "lib/modules" has been renamed to modules, but you will need to
@@ -137,26 +116,18 @@ function refactor({ argv }) {
   }
   injectHelpersIfNeeded();
 
-  function processLibModules() {
+  function manageSingleProject() {
     // Only touch directories, don't mess about with regular files in lib/modules
     // or symlinks in lib/modules
-    let moduleNames = fs.readdirSync('lib/modules').filter(moduleName => fs.lstatSync(`lib/modules/${moduleName}`).isDirectory());
+    let moduleNames = fs.readdirSync('lib/modules')
+      .filter(moduleName => fs.lstatSync(`lib/modules/${moduleName}`).isDirectory());
     moduleNames.forEach(name => {
       rename(`lib/modules/${name}`, `modules/${name}`);
     });
     try {
       fs.rmdirSync('lib/modules');
     } catch (e) {
-      if (e.code === 'ENOTEMPTY') {
-        console.error(stripIndent`
-          "lib/modules" is not empty after moving modules to "modules". You probably
-          have files that are not apostrophe modules in that folder. Please
-          move those files to a more appropriate location, like "lib", then
-          remove "lib/modules" yourself.
-        `);
-      } else {
-        throw e;
-      }
+      removeModuleFolderError(e);
     }
     moduleNames = fs.readdirSync('modules');
     moduleNames.forEach(moduleName => {
@@ -164,8 +135,51 @@ function refactor({ argv }) {
     });
   }
 
+  function manageMultiSiteProject() {
+    const modulesLocations = [ 'dashboard', 'sites' ];
+
+    modulesLocations.forEach((folderName) => {
+      const moduleNames = fs.readdirSync(`${folderName}/lib/modules`)
+        .filter((moduleName) => fs.lstatSync(`${folderName}/lib/modules/${moduleName}`).isDirectory());
+
+      moduleNames.forEach(name => {
+        rename(`${folderName}/lib/modules/${name}`, `${folderName}/modules/${name}`);
+      });
+    });
+
+    try {
+      modulesLocations.forEach((location) => {
+        fs.rmdirSync((`${location}/lib/modules`));
+      });
+    } catch (e) {
+      removeModuleFolderError(e);
+    }
+
+    modulesLocations.forEach((location) => {
+      const modules = fs.readdirSync(`${location}/modules`);
+
+      modules.forEach((moduleName) => {
+        processModuleInFolder(`${location}/modules`, moduleName);
+      });
+    });
+  }
+
+  function removeModuleFolderError(e) {
+    if (e.code === 'ENOTEMPTY') {
+      console.error(stripIndent`
+          "lib/modules" is not empty after moving modules to "modules". You probably
+          have files that are not Apostrophe modules in that folder. Please
+          move those files to a more appropriate location, like "lib", then
+          remove "lib/modules" yourself.
+        `);
+    } else {
+      throw e;
+    }
+  }
+
   function processModuleInFolder(folder, moduleName) {
     moduleName = renamedModulesMap[moduleName] || moduleName;
+
     let moduleFilename = `${folder}/${moduleName}/index.js`;
     if (!fs.existsSync(moduleFilename)) {
       // Not all project level modules have an index.js file, but
@@ -184,6 +198,7 @@ function refactor({ argv }) {
       const newModuleFilename = moduleFilename.replace(`${moduleName}/index.js`, `${newModuleName}/index.js`);
       // Rename the module folder, the index.js part doesn't change
       rename(path.dirname(moduleFilename), path.dirname(newModuleFilename));
+      // TODO: This mapping should be managed for each folder in multisite case
       renamedModulesMap[moduleName] = newModuleName;
       return newModuleFilename;
     }
@@ -1127,14 +1142,24 @@ function isSingleSiteProject() {
   return fs.existsSync('app.js') && fs.existsSync('lib/modules');
 }
 
+function isMultiSiteProject() {
+  return fs.existsSync('app.js') &&
+    fs.existsSync(('dashboard/lib/modules')) &&
+    fs.existsSync(('sites/lib/modules'));
+}
+
 function isSingleNpmModule() {
   // There is no way to be absolutely sure it isn't some unrelated
   // kind of npm module, but this is a good sanity check
-  return fs.existsSync('package.json') && fs.existsSync('index.js') && !fs.readFileSync('index.js', 'utf8').includes('moogBundle');
+  return fs.existsSync('package.json') &&
+    fs.existsSync('index.js') &&
+    !fs.readFileSync('index.js', 'utf8').includes('moogBundle');
 }
 
 function isMoogBundle() {
-  return fs.existsSync('package.json') && fs.existsSync('index.js') && fs.readFileSync('index.js', 'utf8').includes('moogBundle');
+  return fs.existsSync('package.json') &&
+    fs.existsSync('index.js') &&
+    fs.readFileSync('index.js', 'utf8').includes('moogBundle');
 }
 
 function nameToLiteralOrIdentifier(name) {

--- a/lib/upgrader.js
+++ b/lib/upgrader.js
@@ -10,7 +10,7 @@ const replaceAll = require('string.prototype.replaceall');
 const fail = require('./fail.js');
 const get = require('./get.js');
 const legacyModuleNameMap = require('./legacy-module-name-map.js');
-const globByExtension = require('./glob-by-extension.js');
+const { globByExtension, globByPattern } = require('./glob-by-extension.js');
 
 // This is a random identifier not used anywhere else
 const blankLineMarker = '// X0k7FEu5a6!bC6mV';
@@ -41,6 +41,19 @@ module.exports = ({ argv }) => {
   `);
 
 };
+
+function replaceOccurences(files, replaces) {
+  for (const file of files) {
+    const original = fs.readFileSync(file, { encoding: 'utf8' });
+    let transformed = original;
+    for (const [ pattern, replacement ] of replaces) {
+      transformed = replaceAll(transformed, pattern, replacement);
+    }
+    if (original !== transformed) {
+      fs.writeFileSync(file, transformed);
+    }
+  }
+}
 
 // Simple transformations involving global replace
 function replace({ argv }) {
@@ -73,16 +86,30 @@ function replace({ argv }) {
     [ 'apos.areas.plaintext', 'apos.area.plaintext' ],
     [ 'apos.areas.walk', 'apos.area.walk' ]
   ];
-  for (const file of files) {
-    const original = fs.readFileSync(file, { encoding: 'utf8' });
-    let transformed = original;
-    for (const [ pattern, replacement ] of replaces) {
-      transformed = replaceAll(transformed, pattern, replacement);
-    }
-    if (original !== transformed) {
-      fs.writeFileSync(file, transformed);
-    }
-  }
+
+  replaceOccurences(files, replaces);
+}
+
+function renameModulesDeclarations(isMultisite) {
+  const files = [
+    './app.js',
+    ...isMultisite
+      ? [
+        'dashboard/index.js',
+        'sites/index.js',
+        ...globByPattern('./dashboard/lib/theme-*.js'),
+        ...globByPattern('./sites/lib/theme-*.js')
+      ]
+      : []
+  ];
+
+  const replaces = Object.entries(renamedModulesMap).map(([ old, newName ]) => {
+    const oldName = old.replace('dashboard/', '').replace('sites/', '');
+
+    return [ `'${oldName}'`, `'${newName}'` ];
+  }, []);
+
+  replaceOccurences(files, replaces);
 }
 
 // Heavy duty transformations involving an actual javascript parser
@@ -133,6 +160,7 @@ function refactor({ argv }) {
     moduleNames.forEach(moduleName => {
       processModuleInFolder('modules', moduleName);
     });
+
   }
 
   function manageMultiSiteProject() {
@@ -159,9 +187,11 @@ function refactor({ argv }) {
       const modules = fs.readdirSync(`${location}/modules`);
 
       modules.forEach((moduleName) => {
-        processModuleInFolder(`${location}/modules`, moduleName);
+        processModuleInFolder(`${location}/modules`, moduleName, `${location}/`);
       });
     });
+
+    renameModulesDeclarations(true);
   }
 
   function removeModuleFolderError(e) {
@@ -177,29 +207,28 @@ function refactor({ argv }) {
     }
   }
 
-  function processModuleInFolder(folder, moduleName) {
-    moduleName = renamedModulesMap[moduleName] || moduleName;
+  function processModuleInFolder(folder, moduleName, distinguishFolder = '') {
+    const renamedModule = renamedModulesMap[moduleName] || moduleName;
 
-    let moduleFilename = `${folder}/${moduleName}/index.js`;
+    let moduleFilename = `${folder}/${renamedModule}/index.js`;
     if (!fs.existsSync(moduleFilename)) {
       // Not all project level modules have an index.js file, but
       // always create at least a minimal index.js file to
       // avoid problems if anything must be hoisted there
       // from a template, etc.
-      fs.writeFileSync(moduleFilename, 'module.exports = {};\n');
+      fs.writeFileSync(moduleFilename, 'module.exports = {};');
     }
-    const newModuleName = filterModuleName(moduleName);
-    if (newModuleName !== moduleName) {
-      moduleFilename = renameModule(moduleName, newModuleName);
+    const newModuleName = filterModuleName(renamedModule);
+    if (newModuleName !== renamedModule) {
+      moduleFilename = renameModule(renamedModule, newModuleName);
     }
-    return processModule(moduleName, moduleFilename, { renameModule });
+    return processModule(renamedModule, moduleFilename, { renameModule });
 
-    function renameModule(moduleName, newModuleName) {
-      const newModuleFilename = moduleFilename.replace(`${moduleName}/index.js`, `${newModuleName}/index.js`);
+    function renameModule(renamedModule, newModuleName) {
+      const newModuleFilename = moduleFilename.replace(`${renamedModule}/index.js`, `${newModuleName}/index.js`);
       // Rename the module folder, the index.js part doesn't change
       rename(path.dirname(moduleFilename), path.dirname(newModuleFilename));
-      // TODO: This mapping should be managed for each folder in multisite case
-      renamedModulesMap[moduleName] = newModuleName;
+      renamedModulesMap[`${distinguishFolder}${renamedModule}`] = newModuleName;
       return newModuleFilename;
     }
   }


### PR DESCRIPTION
[PRO-2316/](https://linear.app/apostrophecms/issue/PRO-2316/code-upgrader-tech-design-for-assembly-project-detection-and-support)

## Summary

Adapt code upgrade to be able to run on A2 assembly projects, basically it does the same job but parses **sites** and **dashboard** folders, to rename and bring needed modifications to each module.
A feature has been added to replaces old module names with new ones in configuration files:
* **app.js** in standard projects
* **app.js** / **index.js** /**theme-*.js** in dashboard and sites folders. It's based on renamed modules and on existing mapping legacy to new module names.
Some code has been extracted in functions to avoid duplication.

## What are the specific steps to test this change?

> 1. Run the bin upgrade in a A2 assembly project
> 2. You should see no errors
> 3. Modules should have been renamed
> 4. Modules should have been updated (same behavior as before)
> 5. Modules occurences should have been renamed in app.js / index.js (sites and dashboard) / theme-*.js
> 6. Lint command should still work as expected. 

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
